### PR TITLE
test: lyt-4-store-git-unit-tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "build": "tsdown src/index.ts --format esm --target node20 --out-dir dist",
-    "start": "node ./dist/cli.js"
+    "start": "node ./dist/cli.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@clack/prompts": "^1.0.1",
@@ -26,7 +28,8 @@
     "@types/node": "^20.0.0",
     "tsdown": "^0.20.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
   },
   "imports": {
     "#package.json": "./package.json"

--- a/packages/cli/src/__tests__/git.test.ts
+++ b/packages/cli/src/__tests__/git.test.ts
@@ -1,0 +1,125 @@
+import { execSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import {
+  currentBranch,
+  GitError,
+  isGitRepo,
+  isMergedInto,
+  listLocalBranches,
+  parseOwnerRepo,
+} from '../git.ts';
+
+vi.mock('node:child_process');
+
+// git.ts always calls execSync with encoding:'utf8', so it returns string, not Buffer.
+// The overloaded execSync type can't be directly narrowed without going through unknown.
+const mockExecSync = vi.mocked(execSync) as unknown as MockInstance<() => string>;
+
+beforeEach(() => {
+  mockExecSync.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── parseOwnerRepo ───────────────────────────────────────────────────────────
+
+describe('parseOwnerRepo', () => {
+  it('parses HTTPS URL', () => {
+    expect(parseOwnerRepo('https://github.com/owner/repo')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('parses HTTPS URL with .git suffix', () => {
+    expect(parseOwnerRepo('https://github.com/owner/repo.git')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('parses SSH URL', () => {
+    expect(parseOwnerRepo('git@github.com:owner/repo.git')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('throws GitError for non-GitHub URLs', () => {
+    expect(() => parseOwnerRepo('https://gitlab.com/owner/repo')).toThrow(
+      GitError,
+    );
+  });
+
+  it('throws GitError for malformed input', () => {
+    expect(() => parseOwnerRepo('not-a-url')).toThrow(GitError);
+  });
+});
+
+// ─── GitError ─────────────────────────────────────────────────────────────────
+
+describe('GitError', () => {
+  it('has name GitError', () => {
+    const err = new GitError('oops');
+    expect(err.name).toBe('GitError');
+    expect(err.message).toBe('oops');
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+// ─── isGitRepo ────────────────────────────────────────────────────────────────
+
+describe('isGitRepo', () => {
+  it('returns true when git rev-parse succeeds', () => {
+    mockExecSync.mockReturnValue('.git\n');
+    expect(isGitRepo()).toBe(true);
+  });
+
+  it('returns false when git rev-parse throws', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not a git repo');
+    });
+    expect(isGitRepo()).toBe(false);
+  });
+});
+
+// ─── currentBranch ────────────────────────────────────────────────────────────
+
+describe('currentBranch', () => {
+  it('returns the trimmed branch name', () => {
+    mockExecSync.mockReturnValue('main\n');
+    expect(currentBranch()).toBe('main');
+  });
+});
+
+// ─── listLocalBranches ───────────────────────────────────────────────────────
+
+describe('listLocalBranches', () => {
+  it('splits output into branch names', () => {
+    mockExecSync.mockReturnValue('main\nfeat_a\nfeat_b\n');
+    expect(listLocalBranches()).toEqual(['main', 'feat_a', 'feat_b']);
+  });
+
+  it('filters empty lines', () => {
+    mockExecSync.mockReturnValue('main\n\nfeat_a\n');
+    expect(listLocalBranches()).toEqual(['main', 'feat_a']);
+  });
+});
+
+// ─── isMergedInto ─────────────────────────────────────────────────────────────
+
+describe('isMergedInto', () => {
+  it('returns true when merge-base exits 0', () => {
+    mockExecSync.mockReturnValue('');
+    expect(isMergedInto('feat_a', 'main')).toBe(true);
+  });
+
+  it('returns false when merge-base throws', () => {
+    mockExecSync.mockImplementation(() => {
+      throw Object.assign(new Error('exit 1'), { stderr: Buffer.from('') });
+    });
+    expect(isMergedInto('feat_a', 'main')).toBe(false);
+  });
+});

--- a/packages/cli/src/__tests__/stack.test.ts
+++ b/packages/cli/src/__tests__/stack.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStackSection,
+  getAllDescendants,
+  getAncestors,
+  getChildren,
+  getStack,
+  stripStackSection,
+} from '../stack.ts';
+import type { LyStore } from '../store.ts';
+
+// Strip ANSI escape codes so rendering tests are readable
+function stripAnsi(str: string): string {
+  return str.replace(
+    new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'),
+    '',
+  );
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function linearStore(): LyStore {
+  return {
+    trunk: 'main',
+    branches: {
+      feat_a: { parent: 'main' },
+      feat_b: { parent: 'feat_a' },
+      feat_c: { parent: 'feat_b' },
+    },
+  };
+}
+
+function treeStore(): LyStore {
+  return {
+    trunk: 'main',
+    branches: {
+      feat_a: { parent: 'main' },
+      feat_b: { parent: 'main' },
+      feat_c: { parent: 'feat_a' },
+      feat_d: { parent: 'feat_a' },
+    },
+  };
+}
+
+function emptyStore(): LyStore {
+  return { trunk: 'main', branches: {} };
+}
+
+// ─── getChildren ─────────────────────────────────────────────────────────────
+
+describe('getChildren', () => {
+  it('returns direct children of trunk', () => {
+    expect(getChildren(linearStore(), 'main')).toEqual(['feat_a']);
+  });
+
+  it('returns multiple children', () => {
+    const children = getChildren(treeStore(), 'main');
+    expect(children).toHaveLength(2);
+    expect(children).toContain('feat_a');
+    expect(children).toContain('feat_b');
+  });
+
+  it('returns empty array for a leaf branch', () => {
+    expect(getChildren(linearStore(), 'feat_c')).toEqual([]);
+  });
+
+  it('returns empty array when trunk has no branches', () => {
+    expect(getChildren(emptyStore(), 'main')).toEqual([]);
+  });
+});
+
+// ─── getAllDescendants ────────────────────────────────────────────────────────
+
+describe('getAllDescendants', () => {
+  it('returns BFS-ordered descendants of trunk', () => {
+    const descendants = getAllDescendants(linearStore(), 'main');
+    expect(descendants).toEqual(['feat_a', 'feat_b', 'feat_c']);
+  });
+
+  it('returns BFS order for branching tree', () => {
+    const descendants = getAllDescendants(treeStore(), 'main');
+    // feat_a and feat_b come before their children
+    expect(descendants.indexOf('feat_a')).toBeLessThan(
+      descendants.indexOf('feat_c'),
+    );
+    expect(descendants.indexOf('feat_a')).toBeLessThan(
+      descendants.indexOf('feat_d'),
+    );
+    expect(descendants).toHaveLength(4);
+  });
+
+  it('returns empty array for a leaf', () => {
+    expect(getAllDescendants(linearStore(), 'feat_c')).toEqual([]);
+  });
+});
+
+// ─── getAncestors ─────────────────────────────────────────────────────────────
+
+describe('getAncestors', () => {
+  it('returns empty array for a branch directly on trunk', () => {
+    expect(getAncestors(linearStore(), 'feat_a')).toEqual([]);
+  });
+
+  it('returns intermediate branches, excluding trunk', () => {
+    expect(getAncestors(linearStore(), 'feat_c')).toEqual(['feat_a', 'feat_b']);
+  });
+
+  it('returns single intermediate for two-level stack', () => {
+    expect(getAncestors(linearStore(), 'feat_b')).toEqual(['feat_a']);
+  });
+});
+
+// ─── getStack ────────────────────────────────────────────────────────────────
+
+describe('getStack', () => {
+  it('includes trunk and branch for a direct stack member', () => {
+    expect(getStack(linearStore(), 'feat_a')).toEqual(['main', 'feat_a']);
+  });
+
+  it('returns full path trunk → branch for deep stack', () => {
+    expect(getStack(linearStore(), 'feat_c')).toEqual([
+      'main',
+      'feat_a',
+      'feat_b',
+      'feat_c',
+    ]);
+  });
+});
+
+// ─── buildStackSection ───────────────────────────────────────────────────────
+
+describe('buildStackSection', () => {
+  it('marks the current branch with "← this PR"', () => {
+    const section = buildStackSection(linearStore(), 'feat_a');
+    expect(section).toContain('← this PR');
+    expect(section).toContain('feat_a');
+  });
+
+  it('includes trunk label', () => {
+    const section = buildStackSection(linearStore(), 'feat_a');
+    expect(section).toContain('main');
+    expect(section).toContain('trunk');
+  });
+
+  it('includes descendants below the current branch', () => {
+    const section = buildStackSection(linearStore(), 'feat_a');
+    expect(section).toContain('feat_b');
+    expect(section).toContain('feat_c');
+  });
+
+  it('wraps content with lythium stack markers', () => {
+    const section = buildStackSection(linearStore(), 'feat_a');
+    expect(section).toContain('<!-- lythium-stack-start -->');
+    expect(section).toContain('<!-- lythium-stack-end -->');
+  });
+
+  it('renders PR link when prUrl and prNumber are present', () => {
+    const store: LyStore = {
+      trunk: 'main',
+      branches: {
+        feat_a: {
+          parent: 'main',
+          prNumber: 42,
+          prUrl: 'https://github.com/o/r/pull/42',
+        },
+      },
+    };
+    const section = buildStackSection(store, 'feat_a');
+    expect(section).toContain('https://github.com/o/r/pull/42');
+    expect(section).toContain('#42');
+  });
+});
+
+// ─── stripStackSection ───────────────────────────────────────────────────────
+
+describe('stripStackSection', () => {
+  it('removes an embedded stack section', () => {
+    const body = `My PR description.\n${buildStackSection(linearStore(), 'feat_a')}`;
+    const stripped = stripStackSection(body);
+    expect(stripped).toBe('My PR description.');
+    expect(stripped).not.toContain('lythium-stack');
+  });
+
+  it('is a no-op when no stack section is present', () => {
+    const body = 'Plain PR body.';
+    expect(stripStackSection(body)).toBe('Plain PR body.');
+  });
+
+  it('removes multiple embedded sections', () => {
+    const section = buildStackSection(linearStore(), 'feat_a');
+    const body = `Before\n${section}\nMiddle\n${section}\nAfter`;
+    const stripped = stripStackSection(body);
+    expect(stripped).not.toContain('lythium-stack');
+  });
+});
+
+// ─── renderTree / renderShortStack (smoke tests) ─────────────────────────────
+
+describe('renderTree', () => {
+  it('includes all branch names', async () => {
+    const { renderTree } = await import('../stack.ts');
+    const output = stripAnsi(renderTree(linearStore(), 'main'));
+    expect(output).toContain('main');
+    expect(output).toContain('feat_a');
+    expect(output).toContain('feat_b');
+    expect(output).toContain('feat_c');
+  });
+
+  it('marks the current branch with an asterisk', async () => {
+    const { renderTree } = await import('../stack.ts');
+    const output = stripAnsi(renderTree(linearStore(), 'feat_b'));
+    expect(output).toContain('feat_b *');
+  });
+
+  it('shows a message when no stacks exist', async () => {
+    const { renderTree } = await import('../stack.ts');
+    const output = stripAnsi(renderTree(emptyStore(), 'main'));
+    expect(output).toContain('no stacks');
+  });
+});
+
+describe('renderShortStack', () => {
+  it('lists all branches from trunk to current', async () => {
+    const { renderShortStack } = await import('../stack.ts');
+    const output = stripAnsi(renderShortStack(linearStore(), 'feat_b'));
+    expect(output).toContain('main');
+    expect(output).toContain('feat_a');
+    expect(output).toContain('feat_b');
+  });
+
+  it('marks the current branch with an asterisk', async () => {
+    const { renderShortStack } = await import('../stack.ts');
+    const output = stripAnsi(renderShortStack(linearStore(), 'feat_b'));
+    expect(output).toContain('feat_b *');
+  });
+});

--- a/packages/cli/src/__tests__/store.test.ts
+++ b/packages/cli/src/__tests__/store.test.ts
@@ -1,0 +1,112 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { init, isInitialized, LyError, load, save } from '../store.ts';
+
+vi.mock('../git.ts', () => ({
+  getRepoRoot: vi.fn(),
+}));
+
+import { getRepoRoot } from '../git.ts';
+
+const mockGetRepoRoot = vi.mocked(getRepoRoot);
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = join(
+    tmpdir(),
+    `ly-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(join(tmpRoot, '.git', 'ly'), { recursive: true });
+  mockGetRepoRoot.mockReturnValue(tmpRoot);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── LyError ─────────────────────────────────────────────────────────────────
+
+describe('LyError', () => {
+  it('has name LyError and extends Error', () => {
+    const err = new LyError('boom');
+    expect(err.name).toBe('LyError');
+    expect(err.message).toBe('boom');
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+// ─── isInitialized ───────────────────────────────────────────────────────────
+
+describe('isInitialized', () => {
+  it('returns false when meta.json does not exist', () => {
+    expect(isInitialized()).toBe(false);
+  });
+
+  it('returns true when meta.json exists', () => {
+    writeFileSync(
+      join(tmpRoot, '.git', 'ly', 'meta.json'),
+      JSON.stringify({ trunk: 'main', branches: {} }),
+    );
+    expect(isInitialized()).toBe(true);
+  });
+});
+
+// ─── load ────────────────────────────────────────────────────────────────────
+
+describe('load', () => {
+  it('throws LyError when not initialized', () => {
+    expect(() => load()).toThrow(LyError);
+  });
+
+  it('returns parsed store when meta.json exists', () => {
+    const store = { trunk: 'main', branches: { feat_a: { parent: 'main' } } };
+    writeFileSync(
+      join(tmpRoot, '.git', 'ly', 'meta.json'),
+      JSON.stringify(store),
+    );
+    expect(load()).toEqual(store);
+  });
+});
+
+// ─── save ────────────────────────────────────────────────────────────────────
+
+describe('save', () => {
+  it('writes the store as pretty-printed JSON', () => {
+    const store = { trunk: 'main', branches: {} };
+    save(store);
+    const loaded = load();
+    expect(loaded).toEqual(store);
+  });
+
+  it('persists branch metadata', () => {
+    const store = {
+      trunk: 'main',
+      branches: {
+        feat_a: {
+          parent: 'main',
+          prNumber: 7,
+          prUrl: 'https://github.com/o/r/pull/7',
+        },
+      },
+    };
+    save(store);
+    expect(load()).toEqual(store);
+  });
+});
+
+// ─── init ────────────────────────────────────────────────────────────────────
+
+describe('init', () => {
+  it('creates a store with the given trunk and no branches', () => {
+    const store = init('main');
+    expect(store).toEqual({ trunk: 'main', branches: {} });
+  });
+
+  it('persists the store so load() can read it back', () => {
+    init('develop');
+    expect(load()).toEqual({ trunk: 'develop', branches: {} });
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+  },
+});


### PR DESCRIPTION
<!-- lythium-stack-start -->
---
*Stack — managed by [lythium](https://github.com/jhechtf/lythium):*

- `main` (trunk)
- [feat/lyt-4-vitest-setup](https://github.com/jhechtf/lythium/pull/10) (#10)
- **[test/lyt-4-store-git-unit-tests](https://github.com/jhechtf/lythium/pull/11) (#11) ← this PR**
- [test/lyt-4-integration-tests](https://github.com/jhechtf/lythium/pull/12) (#12)
- [test/lyt-4-github-api-tests](https://github.com/jhechtf/lythium/pull/13) (#13)
- [ci/lyt-4-github-actions](https://github.com/jhechtf/lythium/pull/14) (#14)
<!-- lythium-stack-end -->