### PR TITLE
feat: Update sync to allow you to rebuild the local stack graph

### DIFF
--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -5,7 +5,7 @@ import { renderShortStack, renderTree } from '../stack.ts';
 import { LyError, type LyStore, load } from '../store.ts';
 
 program
-  .command('log')
+  .command('log', { isDefault: true })
   .description('Show the stack tree')
   .option('-s, --short', 'show only the current stack lineage')
   .action((opts: { short?: boolean }) => {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,41 +1,268 @@
 import { isCancel, multiselect, outro } from '@clack/prompts';
 import { program } from 'commander';
 import pc from 'picocolors';
+import { fetch as undiciFetch } from 'undici';
+import { getToken } from '../credentials.ts';
 import {
   checkout,
   currentBranch,
   deleteBranch,
   fetch,
   forceRebase,
+  getRemoteUrl,
   isMergedInto,
+  listLocalBranches,
+  parseOwnerRepo,
+  trackRemoteBranch,
 } from '../git.ts';
-import { getAllDescendants } from '../stack.ts';
-import { LyError, type LyStore, load, save } from '../store.ts';
+import { getAllDescendants, STACK_END, STACK_START } from '../stack.ts';
+import {
+  type BranchMeta,
+  LyError,
+  type LyStore,
+  load,
+  save,
+} from '../store.ts';
+
+// ─── Rebuild helpers ──────────────────────────────────────────────────────────
+
+interface ParsedEntry {
+  name: string;
+  prNumber?: number;
+  prUrl?: string;
+  isTrunk: boolean;
+}
+
+interface GithubPR {
+  body: string | null;
+}
+
+async function githubGet<T>(path: string, token: string): Promise<T> {
+  const res = await undiciFetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'lythium-cli',
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub API error ${res.status}: ${text}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function parseStackLine(raw: string): ParsedEntry | null {
+  const line = raw
+    .replace(/^-\s+/, '')
+    .replace(/^\*\*/, '')
+    .replace(/\s*←\s*this PR\*\*$/, '')
+    .trim();
+
+  const trunkMatch = line.match(/^`(.+?)`\s+\(trunk\)$/);
+  if (trunkMatch) return { name: trunkMatch[1], isTrunk: true };
+
+  const prMatch = line.match(/^\[(.+?)\]\((.+?)\)\s+\(#(\d+)\)$/);
+  if (prMatch) {
+    return {
+      name: prMatch[1],
+      prUrl: prMatch[2],
+      prNumber: Number.parseInt(prMatch[3], 10),
+      isTrunk: false,
+    };
+  }
+
+  const nameMatch = line.match(/^`(.+?)`$/);
+  if (nameMatch) return { name: nameMatch[1], isTrunk: false };
+
+  return null;
+}
+
+function parseStackSection(body: string): ParsedEntry[] | null {
+  const startIdx = body.indexOf(STACK_START);
+  const endIdx = body.indexOf(STACK_END);
+  if (startIdx === -1 || endIdx === -1) return null;
+
+  const section = body.slice(startIdx + STACK_START.length, endIdx);
+  const entries = section
+    .split('\n')
+    .filter((l) => l.trim().startsWith('-'))
+    .map(parseStackLine)
+    .filter((e): e is ParsedEntry => e !== null);
+
+  return entries.length > 0 ? entries : null;
+}
+
+async function rebuildStore(
+  owner: string,
+  repo: string,
+  token: string,
+): Promise<LyStore> {
+  // Page through all open PRs
+  process.stdout.write(pc.dim('Querying open PRs... '));
+  let allPRs: GithubPR[] = [];
+  let page = 1;
+  while (true) {
+    const batch = await githubGet<GithubPR[]>(
+      `/repos/${owner}/${repo}/pulls?state=open&per_page=100&page=${page}`,
+      token,
+    );
+    allPRs = allPRs.concat(batch);
+    if (batch.length < 100) break;
+    page++;
+  }
+  process.stdout.write(pc.green(`✓ (${allPRs.length} open PR(s))\n`));
+
+  const stackPRs = allPRs.filter((pr) => pr.body?.includes(STACK_START));
+  if (stackPRs.length === 0) {
+    throw new LyError(
+      'No open PRs with lythium stack sections found. Cannot rebuild.',
+    );
+  }
+
+  // Union all parsed chains into a single branch graph.
+  // Each chain is ordered trunk → … → leaf, so entry[i]'s parent is entry[i-1].
+  // Prefer entries that carry PR metadata over those that don't.
+  let trunk: string | null = null;
+  const branches: Record<string, BranchMeta> = {};
+
+  for (const pr of stackPRs) {
+    const entries = parseStackSection(pr.body ?? '');
+    if (!entries) continue;
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+
+      if (entry.isTrunk) {
+        trunk = entry.name;
+        continue;
+      }
+
+      const parent = entries[i - 1]?.name ?? trunk;
+      if (!parent) continue;
+
+      const existing = branches[entry.name];
+      if (!existing || (!existing.prNumber && entry.prNumber)) {
+        branches[entry.name] = {
+          parent,
+          ...(entry.prNumber
+            ? { prNumber: entry.prNumber, prUrl: entry.prUrl }
+            : {}),
+        };
+      }
+    }
+  }
+
+  if (!trunk) {
+    throw new LyError('Could not determine trunk branch from stack sections.');
+  }
+
+  // Track remote branches that aren't present locally yet
+  const localBranches = new Set(listLocalBranches());
+  const toTrack = Object.keys(branches).filter((b) => !localBranches.has(b));
+
+  if (toTrack.length > 0) {
+    console.log(pc.dim('\nTracking remote branches:'));
+    for (const b of toTrack) {
+      process.stdout.write(pc.dim(`  ${b}... `));
+      try {
+        trackRemoteBranch(b);
+        process.stdout.write(pc.green('✓\n'));
+      } catch {
+        // Branch hasn't been pushed yet (local-only on originating machine)
+        process.stdout.write(pc.yellow('not on remote, skipping\n'));
+        delete branches[b];
+      }
+    }
+  }
+
+  return { trunk, branches };
+}
+
+// ─── Command ──────────────────────────────────────────────────────────────────
 
 program
   .command('sync')
   .description('Fetch from origin, clean up merged branches, and restack')
-  .action(async () => {
+  .option(
+    '--rebuild',
+    'rebuild the local stack graph from open GitHub PRs (use when switching machines)',
+  )
+  .action(async (opts: { rebuild?: boolean }) => {
     let store: LyStore;
-    try {
-      store = load();
-    } catch (e) {
-      console.error(pc.red(e instanceof LyError ? e.message : String(e)));
-      process.exit(1);
+
+    if (opts.rebuild) {
+      const token = getToken();
+      if (!token) {
+        console.error(
+          pc.red(
+            'Not logged in. Run `ly auth login` to authenticate with GitHub.',
+          ),
+        );
+        process.exit(1);
+      }
+
+      let owner: string;
+      let repo: string;
+      try {
+        ({ owner, repo } = parseOwnerRepo(getRemoteUrl()));
+      } catch (e) {
+        console.error(pc.red((e as Error).message));
+        process.exit(1);
+      }
+
+      // Fetch first so trackRemoteBranch has up-to-date refs
+      process.stdout.write(pc.dim('Fetching from origin... '));
+      try {
+        fetch();
+        process.stdout.write(pc.green('✓\n'));
+      } catch (e) {
+        process.stdout.write(pc.red('✗\n'));
+        console.error(pc.red(`Fetch failed: ${(e as Error).message}`));
+        process.exit(1);
+      }
+
+      try {
+        store = await rebuildStore(owner, repo, token);
+      } catch (e) {
+        console.error(pc.red(e instanceof LyError ? e.message : String(e)));
+        process.exit(1);
+      }
+
+      console.log(
+        pc.dim(
+          `\nRebuilt stack: ${Object.keys(store.branches).length} branch(es) under ${pc.bold(store.trunk)}`,
+        ),
+      );
+    } else {
+      try {
+        store = load();
+      } catch (e) {
+        console.error(pc.red(e instanceof LyError ? e.message : String(e)));
+        if (e instanceof LyError) {
+          console.error(
+            pc.dim(
+              'Tip: run `ly sync --rebuild` to rebuild from open GitHub PRs.',
+            ),
+          );
+        }
+        process.exit(1);
+      }
+
+      // Fetch
+      process.stdout.write(pc.dim('Fetching from origin... '));
+      try {
+        fetch();
+        process.stdout.write(pc.green('✓\n'));
+      } catch (e) {
+        process.stdout.write(pc.red('✗\n'));
+        console.error(pc.red(`Fetch failed: ${(e as Error).message}`));
+        process.exit(1);
+      }
     }
 
-    // 1. Fetch
-    process.stdout.write(pc.dim('Fetching from origin... '));
-    try {
-      fetch();
-      process.stdout.write(pc.green('✓\n'));
-    } catch (e) {
-      process.stdout.write(pc.red('✗\n'));
-      console.error(pc.red(`Fetch failed: ${(e as Error).message}`));
-      process.exit(1);
-    }
-
-    // 2. Detect merged branches
+    // Detect merged branches
     const trackedBranches = Object.keys(store.branches);
     const merged = trackedBranches.filter((b) => {
       try {
@@ -63,7 +290,6 @@ program
 
       if (!isCancel(toDelete)) {
         for (const b of toDelete as string[]) {
-          // Move children of deleted branch up to its parent
           const meta = store.branches[b];
           const children = Object.entries(store.branches).filter(
             ([, m]) => m.parent === b,
@@ -73,7 +299,6 @@ program
             console.log(pc.dim(`  Reparenting ${child} → ${meta.parent}`));
           }
 
-          // Delete branch (switch away first if needed)
           if (currentBranch() === b) {
             checkout(meta.parent);
           }
@@ -90,7 +315,7 @@ program
       console.log(pc.dim('No merged branches found.'));
     }
 
-    // 3. Restack remaining branches
+    // Restack remaining branches
     const toRestack = getAllDescendants(store, store.trunk);
     if (toRestack.length > 0) {
       console.log(pc.dim(`\nRestacking ${toRestack.length} branch(es)...`));

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -145,6 +145,10 @@ export function deleteBranch(branch: string, force = false): void {
   git(`branch ${force ? '-D' : '-d'} ${branch}`);
 }
 
+export function trackRemoteBranch(branch: string): void {
+  git(`branch --track ${branch} origin/${branch}`);
+}
+
 export function getRemoteUrl(): string {
   return git('remote get-url origin');
 }

--- a/packages/cli/src/stack.ts
+++ b/packages/cli/src/stack.ts
@@ -41,8 +41,8 @@ export function getStack(store: LyStore, branch: string): string[] {
 
 // ─── PR body stack section ───────────────────────────────────────────────────
 
-const STACK_START = '<!-- lythium-stack-start -->';
-const STACK_END = '<!-- lythium-stack-end -->';
+export const STACK_START = '<!-- lythium-stack-start -->';
+export const STACK_END = '<!-- lythium-stack-end -->';
 
 function formatBranchEntry(store: LyStore, b: string): string {
   const meta = store.branches[b];


### PR DESCRIPTION
Since we push data into a file in the `.git` directory we need to be able to rebuild the stack state. Might move this over to an endpoint in the API in the future but this seems to be easiest so far, especially for the current repo.

<!-- lythium-stack-start -->
---
*Stack — managed by [lythium](https://github.com/jhechtf/lythium):*

- `main` (trunk)
- **[update-sync](https://github.com/jhechtf/lythium/pull/36) (#36) ← this PR**
<!-- lythium-stack-end -->